### PR TITLE
Support for Codeception 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   ],
   "require": {
     "php": ">= 7.1",
-    "codeception/codeception": "^2.5.1",
+    "codeception/codeception": "^2.5.1|^3.0.2",
     "nette/di": "~2.4.14",
     "nette/bootstrap": "~2.4.6",
     "nette/http": "~2.4.10",

--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,7 @@
     ],
     "phpstan-install": [
       "mkdir -p temp/phpstan",
+      "composer require -d temp/phpstan nette/utils:~2.5.3",
       "composer require -d temp/phpstan phpstan/phpstan:^0.10",
       "composer require -d temp/phpstan phpstan/phpstan-deprecation-rules:^0.10",
       "composer require -d temp/phpstan phpstan/phpstan-nette:^0.10",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -24,3 +24,7 @@ parameters:
 
 		# Complicated to test dev-required phpstan with separatly installed version
 		- '#^Call to an undefined method PHPStan\\#'
+
+		# Symfony 4.3 deprecation message
+		- '#^Class Contributte\\Codeception\\Connector\\NetteConnector extends deprecated class Symfony\\Component\\BrowserKit\\Client\.#'
+


### PR DESCRIPTION
This change allows installation of Codeception 3.
Version 3.0.2 is used because this version has fixed support for PHPUnit 8.2.
