### PR TITLE
Use stable PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 php:
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
   - nightly
 
 before_install:
@@ -46,7 +46,6 @@ jobs:
 
   allow_failures:
     - stage: Test Coverage
-    - php: 7.4snapshot
     - php: nightly
 
 sudo: false


### PR DESCRIPTION
Use stable PHP 7.4, removed PHP 7.4 from allowed failures.