### PR TITLE
Fix temporary directory delete

### DIFF
--- a/src/Module/NetteDIModule.php
+++ b/src/Module/NetteDIModule.php
@@ -135,7 +135,7 @@ class NetteDIModule extends Module
 		]);
 
 		$this->clearTempDir();
-		$tempDir = $this->path . '/' . $this->config['tempDir'];
+		$tempDir = $this->getTempDir();
 		$configurator->setTempDirectory($tempDir);
 
 		if ($this->config['debugMode'] !== null) {

--- a/src/Module/NetteDIModule.php
+++ b/src/Module/NetteDIModule.php
@@ -154,15 +154,32 @@ class NetteDIModule extends Module
 		}
 	}
 
-	private function clearTempDir(): void
+
+	private function getTempDir(): string
 	{
 		$tempDir = $this->path . '/' . $this->config['tempDir'];
+
+		return $tempDir;
+	}
+
+
+	private function clearTempDir(): void
+	{
+		$this->deleteTempDir();
+
+		$tempDir = $this->getTempDir();
+		FileSystem::createDir($tempDir);
+	}
+
+
+	private function deleteTempDir(): void
+	{
+		$tempDir = $this->getTempDir();
 		if (is_dir($tempDir)) {
 			FileSystem::delete(realpath($tempDir));
 		}
-
-		FileSystem::createDir($tempDir);
 	}
+
 
 	private function stopContainer(): void
 	{
@@ -187,7 +204,7 @@ class NetteDIModule extends Module
 			// IJournal is optional
 		}
 
-		FileSystem::delete(realpath($this->container->getParameters()['tempDir']));
+		$this->deleteTempDir();
 	}
 
 }


### PR DESCRIPTION
When 'newContainerForEachTest' is set then temporary directory is
deleted in `_after()` and delete in `_afterSuite()` fails because directory
does not exist.