### PR TITLE
Updated Codeception to version 4.0

### DIFF
--- a/codeception.yml
+++ b/codeception.yml
@@ -6,8 +6,9 @@ paths:
     data: tests/_data
     support: tests/_helpers
 
+bootstrap: _bootstrap.php
+
 settings:
-    bootstrap: _bootstrap.php
     log: true
 
 coverage:

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
   ],
   "require": {
     "php": "^7.2",
-    "codeception/codeception": "^2.5.1 || ^3.0.2",
+    "codeception/codeception": "^4.0.2",
+    "codeception/lib-innerbrowser": "^1.3",
     "nette/di": "^3.0",
     "nette/bootstrap": "^3.0",
     "nette/http": "^3.0.3",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -20,9 +20,6 @@ parameters:
 		# Complicated to test dev-required phpstan with separatly installed version
 		- '#^Call to an undefined method PHPStan\\#'
 
-		# Symfony 4.3 deprecation message
-		- '#^Class Contributte\\Codeception\\Connector\\NetteConnector extends deprecated class Symfony\\Component\\BrowserKit\\Client(.+)#'
-
 	earlyTerminatingMethodCalls:
 		Codeception\Module:
 			- fail

--- a/src/Connector/NetteConnector.php
+++ b/src/Connector/NetteConnector.php
@@ -9,12 +9,12 @@ use Nette\Application\Application;
 use Nette\DI\Container;
 use Nette\Http\IRequest;
 use Nette\Http\IResponse;
-use Symfony\Component\BrowserKit\Client;
+use Symfony\Component\BrowserKit\AbstractBrowser;
 use Symfony\Component\BrowserKit\Request;
 use Symfony\Component\BrowserKit\Response;
 use Throwable;
 
-class NetteConnector extends Client
+class NetteConnector extends AbstractBrowser
 {
 
 	/** @var callable */


### PR DESCRIPTION
Package is now compatible with Codeception 4.

Because Codeception was split into modules it's not possible to support also older versions of Codeception.
