### PR TITLE
Allow ^4.0 for codeception/lib-innerbrowser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   "require": {
     "php": ">= 8.0",
     "codeception/codeception": "^5.0.0",
-    "codeception/lib-innerbrowser": "^3.0",
+    "codeception/lib-innerbrowser": "^3.0 || ^4.0",
     "nette/di": "^3.0.13",
     "nette/bootstrap": "^3.1.2",
     "nette/http": "^3.1.6",


### PR DESCRIPTION
required to allow phpunit/phpunit version `^10`