### PR TITLE
Fix netteConnector with phpunit10

### DIFF
--- a/src/Connector/NetteConnector.php
+++ b/src/Connector/NetteConnector.php
@@ -31,10 +31,12 @@ class NetteConnector extends AbstractBrowser
 	 */
 	public function doRequest($request): Response
 	{
+		$phpSelf = $_SERVER['PHP_SELF'];
 		$_COOKIE = $request->getCookies();
 		$_SERVER = $request->getServer();
 		$_FILES = $request->getFiles();
 
+		$_SERVER['PHP_SELF'] = $phpSelf;
 		$_SERVER['REQUEST_METHOD'] = $method = strtoupper($request->getMethod());
 		$_SERVER['REQUEST_URI'] = str_replace('http://localhost', '', $request->getUri());
 		$_SERVER['REMOTE_ADDR'] = '127.0.0.1';


### PR DESCRIPTION
Because of https://github.com/sebastianbergmann/phpunit/blob/main/src/TextUI/Configuration/Merger.php#L102, phpunit relies on `$_SERVER['PHP_SELF']`. It works fine when there's just one suite. But when there are more, the 2nd suite would fail on the line above because `$_SERVER['PHP_SELF']` would be null and `realpath()` does not accept null.

Perhaps there is a "nicer" solution but this PR fixes the issue I was having completely.

If merged, please tag a new release if at all possible.