### PR TITLE
Fix for 8.2

### DIFF
--- a/src/Http/Response.php
+++ b/src/Http/Response.php
@@ -12,6 +12,15 @@ use Nette\Utils\DateTime;
  */
 class Response implements IResponse
 {
+	
+	/** @var string The domain in which the cookie will be available */
+	public $cookieDomain = '';
+
+	/** @var string The path in which the cookie will be available */
+	public $cookiePath = '/';
+
+	/** @var bool Whether the cookie is available only through HTTPS */
+	public $cookieSecure = false;
 
 	/** @var int */
 	private $code = self::S200_OK;


### PR DESCRIPTION
without this, it fails on these lines https://github.com/nette/http/blob/master/src/Http/Session.php#L62-L65 due to `ErrorException: Creation of dynamic property Contributte\Codeception\Http\Response::$cookiePath is deprecated in `