### PR TITLE
Disable debug mode does not work

### DIFF
--- a/src/Module/NetteDIModule.php
+++ b/src/Module/NetteDIModule.php
@@ -124,7 +124,11 @@ class NetteDIModule extends Module
 				'extensions' => ExtensionsExtension::class,
 			];
 		}
-
+		
+		if ($this->config['debugMode'] !== null) {
+			$configurator->setDebugMode((bool) $this->config['debugMode']);
+		}
+		
 		if ($this->config['logDir'] !== null) {
 			$logDir = $this->path . '/' . $this->config['logDir'];
 			FileSystem::createDir($logDir);
@@ -140,9 +144,7 @@ class NetteDIModule extends Module
 		$tempDir = $this->getTempDir();
 		$configurator->setTempDirectory($tempDir);
 
-		if ($this->config['debugMode'] !== null) {
-			$configurator->setDebugMode((bool) $this->config['debugMode']);
-		}
+
 
 		/** @var iterable<string> $configFiles */
 		$configFiles = $this->configFiles !== [] ? $this->configFiles : $this->config['configFiles'];


### PR DESCRIPTION
toggling debug mode does not work.

Method `enableTracy` uses debugMode in static parameters to choose production/debug mode.
https://github.com/nette/bootstrap/blob/master/src/Bootstrap/Configurator.php#L194

But in current implemetation `setDebug` is called after enableTracy call. So the parameter is not used
https://github.com/nette/bootstrap/blob/4876d25955b4164d714bc17c265f664f6594685b/src/Bootstrap/Configurator.php#L94

And method `detectDebugMode` is used for first set of tests
https://github.com/nette/tracy/blob/59062116fd36efd9579061af1dcbc0472cea1d63/src/Tracy/Debugger/Debugger.php#L599


But in all of the following calls and because of this connector
https://github.com/contributte/codeception/blob/5d2be1b9eba472d1c197106da7b5ff0b020b0a62/src/Connector/NetteConnector.php#L42

Remote address is set to `127.0.0.1`, so the `detectDebugMode` method automatically enables debug mode for tracy in all of the following test cases




