### PR TITLE
Implement Request::getBasicCredentials for http basic auth testing

### DIFF
--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -2,6 +2,7 @@
 
 namespace Contributte\Codeception\Http;
 
+use Exception;
 use Nette\Http\FileUpload;
 use Nette\Http\IRequest;
 use Nette\Http\RequestFactory;
@@ -120,6 +121,23 @@ class Request implements IRequest
 	public function isSameSite(): bool
 	{
 		return true;
+	}
+
+	/**
+	 * Returns basic HTTP authentication credentials.¨
+	 *
+	 * @return array{string, string}|null
+	 */
+	public function getBasicCredentials(): ?array
+	{
+		if (method_exists($this->request, 'getBasicCredentials')) {
+			return $this->request->getBasicCredentials();
+		}
+
+		throw new Exception(sprintf(
+			'getBasicCredentials() method is not available on %s.',
+			get_class($this->request),
+		));
 	}
 
 }

--- a/tests/Functional/src/HttpRequestTest.php
+++ b/tests/Functional/src/HttpRequestTest.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace Functional\src;
+
+use Codeception\Test\Unit;
+use Contributte\Codeception\Http\Request;
+use Contributte\Codeception\Module\NetteApplicationModule;
+use Contributte\Codeception\Module\NetteDIModule;
+use Nette\Http\IRequest;
+
+class HttpRequestTest extends Unit
+{
+
+	/** @var NetteApplicationModule|NetteDIModule */
+	protected $tester;
+
+	public function testHttpRequest(): void
+	{
+		$this->tester->amHttpAuthenticated('username', 'password');
+
+		$this->tester->amOnPage('/article/page');
+
+		$httpRequest = $this->tester->grabService(IRequest::class);
+
+		$this->assertInstanceOf(Request::class, $httpRequest);
+
+		$this->assertSame(['username', 'password'], $httpRequest->getBasicCredentials());
+	}
+
+}


### PR DESCRIPTION
`getBasicCredentials` method is implemented in Nette\Http\Request, but it's not part of IRequest interface, so it was missing in this Codeception\Http\Request implementation. With this change we can use `$this->tester->amHttpAuthenticated()`.

Implemented using `method_exists($this->request, 'getBasicCredentials')` so it's more universal, not depending directly to `Nette\Http\Request `.